### PR TITLE
Made signals responsive

### DIFF
--- a/versions/v2/components/Debugger/Signals/List/styles.css
+++ b/versions/v2/components/Debugger/Signals/List/styles.css
@@ -5,7 +5,7 @@
   margin: 0;
   padding: 0;
   border: 1px solid #DDD;
-  min-width: 200px;
+  width: 100%;
   list-style-type: none;
   height: calc(100vh - 115px);
   overflow-y: scroll;
@@ -18,6 +18,8 @@
   height: 30px;
   line-height: 30px;
   border-bottom: 1px solid #DDD;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .item:hover {

--- a/versions/v2/components/Debugger/Signals/styles.css
+++ b/versions/v2/components/Debugger/Signals/styles.css
@@ -6,6 +6,7 @@
 
 .list {
   flex: 2;
+  min-width: 200px;
 }
 
 .signal {
@@ -50,4 +51,25 @@
 }
 .reset:hover {
   background-color: #FAFAFA;
+}
+
+@media (max-width: 650px) {
+    .list {
+        flex: 0;
+        min-width: 25vw;
+        max-width: 25vw;
+    }
+
+    .list:hover {
+        min-width: inherit;
+        max-width: 80vw;
+    }
+
+    button {
+        font-size: 7px;
+    }
+
+    .list:hover button {
+        font-size: 11px;
+    }
 }


### PR DESCRIPTION
![gif](http://g.recordit.co/3DKclV7yJy.gif)
- hidden fix included, overflow hidden on signal items, so you don't see the "type" over the other items.
