### PR TITLE
Add Arial as the font fallback

### DIFF
--- a/versions/v2/components/Debugger/styles.css
+++ b/versions/v2/components/Debugger/styles.css
@@ -2,7 +2,7 @@
   display: flex;
   flex-direction: column;
   height: 100%;
-  font-family: "Helvetica Neue";
+  font-family: "Helvetica Neue", Arial;
   color: #333;
   background-color: #FAFAFA;
 }


### PR DESCRIPTION
Helvetica Neu is not on windows by default so Times New Roman is used.
